### PR TITLE
test: add pagination test for bscscan fetch

### DIFF
--- a/tests/test_bscscan.py
+++ b/tests/test_bscscan.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import bscscan
+
+
+def test_fetch_all_paginates(monkeypatch):
+    """fetch_all should request subsequent pages until an empty page is returned."""
+    calls = []
+
+    class FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, timeout=10):
+        calls.append(url)
+        if "startblock=0" in url:
+            data = {"result": [{"blockNumber": "1", "hash": "h1"}]}
+        elif "startblock=2" in url:
+            data = {"result": []}
+        else:
+            raise AssertionError(f"Unexpected URL {url}")
+        return FakeResp(data)
+
+    monkeypatch.setattr(bscscan.requests, "get", fake_get)
+    monkeypatch.setattr(bscscan.time, "sleep", lambda _: None)
+
+    df = bscscan.fetch_all("txlist", "0xabc")
+    assert len(df) == 1
+    assert any("startblock=2" in url for url in calls)


### PR DESCRIPTION
## Summary
- add unit test ensuring `fetch_all` paginates until an empty page is returned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68945026ff20833385338ee5388266f9