### PR TITLE
Handle BscScan API errors

### DIFF
--- a/bscscan.py
+++ b/bscscan.py
@@ -27,7 +27,8 @@ def fetch_all(action: Action, address: str) -> pd.DataFrame:
         url = build_url(action, address, start)
         resp = requests.get(url, timeout=10).json()
         data = resp.get("result", [])
-        if not data:
+        # BscScan may return an error string in "result" when status != 1.
+        if not isinstance(data, list) or not data:
             break
         items.extend(data)
         start = int(data[-1]["blockNumber"]) + 1

--- a/tests/test_bscscan.py
+++ b/tests/test_bscscan.py
@@ -33,3 +33,23 @@ def test_fetch_all_paginates(monkeypatch):
     df = bscscan.fetch_all("txlist", "0xabc")
     assert len(df) == 1
     assert any("startblock=2" in url for url in calls)
+
+
+def test_fetch_all_handles_api_error(monkeypatch):
+    """An API error should result in an empty DataFrame."""
+
+    class FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, timeout=10):
+        return FakeResp({"status": "0", "message": "NOTOK", "result": "error"})
+
+    monkeypatch.setattr(bscscan.requests, "get", fake_get)
+    monkeypatch.setattr(bscscan.time, "sleep", lambda _: None)
+
+    df = bscscan.fetch_all("txlist", "0xabc")
+    assert df.empty


### PR DESCRIPTION
## Summary
- Improve fetch_all to gracefully handle BscScan API error responses
- Add regression test for error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894528844888333b9ce2bb5ca11d5ee