### PR TITLE
Handle missing columns in insert_raw

### DIFF
--- a/db.py
+++ b/db.py
@@ -46,29 +46,29 @@ def init_db(con: duckdb.DuckDBPyConnection) -> None:
 def insert_raw(con: duckdb.DuckDBPyConnection, df: pd.DataFrame) -> None:
     if df.empty:
         return
-    con.execute(
-        "INSERT OR IGNORE INTO tx_raw SELECT * FROM df",
-        {"df": df[
-            [
-                "hash",
-                "blockNumber",
-                "timeStamp",
-                "from",
-                "to",
-                "value",
-                "tokenSymbol",
-                "gas",
-                "input",
-            ]
-        ].rename(
-            columns={
-                "blockNumber": "block",
-                "timeStamp": "time",
-                "value": "value_native",
-                "tokenSymbol": "token_symbol",
-            }
-        )},
+    df = df.rename(
+        columns={
+            "blockNumber": "block",
+            "timeStamp": "time",
+            "value": "value_native",
+            "tokenSymbol": "token_symbol",
+        }
+    ).reindex(
+        columns=[
+            "hash",
+            "block",
+            "time",
+            "from",
+            "to",
+            "value_native",
+            "token_symbol",
+            "gas",
+            "input",
+        ]
     )
+    df = df.astype(object).where(pd.notnull(df), None)
+    con.register("df", df)
+    con.execute("INSERT OR IGNORE INTO tx_raw SELECT * FROM df")
 
 
 def insert_edges(con: duckdb.DuckDBPyConnection, df: pd.DataFrame) -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,48 @@
+import pathlib
+import sys
+
+import duckdb
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from db import insert_raw
+
+
+def test_insert_raw_handles_missing_columns():
+    con = duckdb.connect(":memory:")
+    con.execute(
+        """
+        CREATE TABLE tx_raw (
+            hash TEXT PRIMARY KEY,
+            block BIGINT,
+            time TIMESTAMP,
+            "from" TEXT,
+            "to" TEXT,
+            value_native DOUBLE,
+            token_symbol TEXT,
+            gas BIGINT,
+            input TEXT
+        )
+        """
+    )
+
+    df = pd.DataFrame(
+        [
+            {
+                "hash": "h1",
+                "blockNumber": 1,
+                "timeStamp": pd.Timestamp("2024-01-01"),
+                "from": "A",
+                "to": "B",
+                "value": 0.1,
+                # tokenSymbol, gas, input missing
+            }
+        ]
+    )
+
+    insert_raw(con, df)
+
+    row = con.execute(
+        "SELECT token_symbol, gas, input FROM tx_raw WHERE hash='h1'"
+    ).fetchone()
+    assert row == (None, None, None)


### PR DESCRIPTION
## Summary
- ensure `insert_raw` can insert DataFrames missing optional columns by reindexing and registering them
- add regression test for inserting rows with missing columns

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689454c65cd88333b11dbfdad6440888